### PR TITLE
Allow scores to push to an empty yaml file

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -12698,7 +12698,7 @@ function toJson(fileName) {
     return to_json_awaiter(this, void 0, void 0, function* () {
         try {
             const contents = (yield returnReadFile(fileName));
-            return load(contents);
+            return contents ? load(contents) : [];
         }
         catch (error) {
             throw new Error(error);

--- a/src/__tests__/add-game.test.ts
+++ b/src/__tests__/add-game.test.ts
@@ -2,7 +2,7 @@ import addGame from "../add-game";
 
 jest.mock("@actions/core");
 
-const mockReadFile = Promise.resolve(
+let mockReadFile = Promise.resolve(
   JSON.stringify([
     {
       board: ["🟩⬛⬛⬛⬛", "⬛⬛🟨🟩🟨", "🟩🟩🟩🟩🟩"],
@@ -52,6 +52,25 @@ describe("addGame", () => {
         score: 3,
         won: true,
       },
+      {
+        board: ["🟩⬛⬛⬛⬛", "⬛⬛🟨🟩🟨", "🟩🟩🟩🟩🟩"],
+        boardWords: [
+          "yes no no no no",
+          "no no almost yes almost",
+          "yes yes yes yes yes",
+        ],
+        date: "2022-01-18",
+        number: 210,
+        score: 3,
+        won: true,
+      },
+    ]);
+  });
+
+  test("can add wordle game to empty yaml file", async () => {
+    jest.useFakeTimers().setSystemTime(new Date("2022-01-18").getTime());
+    mockReadFile = Promise.resolve("");
+    expect(await addGame({ ...sample, fileName: "my-wordle.yml" })).toEqual([
       {
         board: ["🟩⬛⬛⬛⬛", "⬛⬛🟨🟩🟨", "🟩🟩🟩🟩🟩"],
         boardWords: [

--- a/src/__tests__/add-game.test.ts
+++ b/src/__tests__/add-game.test.ts
@@ -1,8 +1,9 @@
 import addGame from "../add-game";
 
 jest.mock("@actions/core");
-jest.mock("../to-json", () => {
-  return jest.fn(() => [
+
+const mockReadFile = Promise.resolve(
+  JSON.stringify([
     {
       board: ["🟩⬛⬛⬛⬛", "⬛⬛🟨🟩🟨", "🟩🟩🟩🟩🟩"],
       boardWords: [
@@ -15,7 +16,11 @@ jest.mock("../to-json", () => {
       score: 3,
       won: true,
     },
-  ]);
+  ])
+);
+
+jest.mock("../read-file", () => {
+  return jest.fn().mockImplementation(() => mockReadFile);
 });
 
 const sample = {
@@ -33,6 +38,7 @@ const sample = {
 describe("addGame", () => {
   test("works", async () => {
     jest.useFakeTimers().setSystemTime(new Date("2022-01-18").getTime());
+
     expect(await addGame({ ...sample, fileName: "my-wordle.yml" })).toEqual([
       {
         board: ["🟩⬛⬛⬛⬛", "⬛⬛🟨🟩🟨", "🟩🟩🟩🟩🟩"],

--- a/src/to-json.ts
+++ b/src/to-json.ts
@@ -4,7 +4,7 @@ import { load } from "js-yaml";
 export default async function toJson(fileName: string) {
   try {
     const contents = (await returnReadFile(fileName)) as string;
-    return load(contents);
+    return contents ? load(contents) : [];
   } catch (error) {
     throw new Error(error);
   }


### PR DESCRIPTION
In #15, the error `[TypeError: Cannot read properties of undefined (reading 'push')` appeared when attempting to add a game to an empty yaml file. This PR fixes the bug by return an empty array if the destination yaml file is empty.