### PR TITLE
Allow scores to push to an empty yaml file that has whitespace

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -12636,7 +12636,9 @@ function toJson(fileName) {
     return to_json_awaiter(this, void 0, void 0, function* () {
         try {
             const contents = (yield returnReadFile(fileName));
-            return contents ? load(contents) : [];
+            return contents && typeof load(contents.trim()) === "object"
+                ? load(contents)
+                : [];
         }
         catch (error) {
             throw new Error(error);

--- a/src/__tests__/add-game.test.ts
+++ b/src/__tests__/add-game.test.ts
@@ -89,7 +89,8 @@ describe("addGame", () => {
   test("can add wordle game to yaml file with whitespace", async () => {
     jest.useFakeTimers().setSystemTime(new Date("2022-01-18").getTime());
     mockReadFile = Promise.resolve(`
-`);
+
+  `);
     expect(await addGame({ ...sample, fileName: "my-wordle.yml" })).toEqual([
       {
         board: ["🟩⬛⬛⬛⬛", "⬛⬛🟨🟩🟨", "🟩🟩🟩🟩🟩"],

--- a/src/__tests__/add-game.test.ts
+++ b/src/__tests__/add-game.test.ts
@@ -85,4 +85,24 @@ describe("addGame", () => {
       },
     ]);
   });
+
+  test("can add wordle game to yaml file with whitespace", async () => {
+    jest.useFakeTimers().setSystemTime(new Date("2022-01-18").getTime());
+    mockReadFile = Promise.resolve(`
+`);
+    expect(await addGame({ ...sample, fileName: "my-wordle.yml" })).toEqual([
+      {
+        board: ["🟩⬛⬛⬛⬛", "⬛⬛🟨🟩🟨", "🟩🟩🟩🟩🟩"],
+        boardWords: [
+          "yes no no no no",
+          "no no almost yes almost",
+          "yes yes yes yes yes",
+        ],
+        date: "2022-01-18",
+        number: 210,
+        score: 3,
+        won: true,
+      },
+    ]);
+  });
 });

--- a/src/to-json.ts
+++ b/src/to-json.ts
@@ -4,7 +4,9 @@ import { load } from "js-yaml";
 export default async function toJson(fileName: string) {
   try {
     const contents = (await returnReadFile(fileName)) as string;
-    return contents ? load(contents) : [];
+    return contents && typeof load(contents.trim()) === "object"
+      ? load(contents)
+      : [];
   } catch (error) {
     throw new Error(error);
   }


### PR DESCRIPTION
In https://github.com/katydecorah/wordle-to-yaml-action/issues/20, the error `[TypeError: Cannot read properties of undefined (reading 'push')` appeared when attempting to add a game to new yaml file that has whitespace / returns. 

Fixes #20 
